### PR TITLE
Add stream_errors enum to error.hpp

### DIFF
--- a/include/boost/asio/gnutls/error.hpp
+++ b/include/boost/asio/gnutls/error.hpp
@@ -36,6 +36,13 @@ public:
 
 namespace error {
 
+enum stream_errors
+{
+  stream_truncated = 1,
+  unspecified_system_error = 2,
+  unexpected_result = 3
+};
+
 static const boost::system::error_category& get_ssl_category()
 {
     static error_category instance;


### PR DESCRIPTION
Adding the `stream_errors` enum present in [boost/asio/ssl/error.hpp](https://github.com/boostorg/asio/blob/boost-1.73.0/include/boost/asio/ssl/error.hpp)