### PR TITLE
re-handshake support for secure re-negotiation

### DIFF
--- a/include/boost/asio/gnutls/stream.hpp
+++ b/include/boost/asio/gnutls/stream.hpp
@@ -644,8 +644,16 @@ private:
                     ec = error_code(ret, error::get_ssl_category());
             }
 
-            auto handler = std::exchange(handshake_handler, nullptr);
-            post(std::bind(std::move(handler), ec));
+            if (handshake_handler != nullptr)
+            {
+                auto handler = std::exchange(handshake_handler, nullptr);
+                post(std::bind(std::move(handler), ec));
+            }
+        }
+
+        bool is_safe_renegotiation_enabled()
+        {
+            return gnutls_safe_renegotiation_status(session) != 0;
         }
 
         void handle_shutdown(error_code ec = {})
@@ -682,6 +690,8 @@ private:
                 {
                     if (ret == GNUTLS_E_AGAIN)
                         ec = boost::asio::error::would_block;
+                    else if (ret == GNUTLS_E_REHANDSHAKE && is_safe_renegotiation_enabled())
+                        handle_handshake(ec);
                     else if (gnutls_error_is_fatal(ret))
                         ec = error_code(ret, error::get_ssl_category());
                     else


### PR DESCRIPTION
Adding re-handshake support for when secure renegotiation is requested according to https://www.gnutls.org/manual/html_node/Re_002dauthentication.html

For security purpose re handshake is performed only when gnutls_safe_renegotiation_status (session) returns non (0)

All test are passing.